### PR TITLE
fix(ui): resolve mobile overflow and align blog header layout

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -10,18 +10,19 @@ type Props = CollectionEntry<"blog">["data"];
 const { title, description, pubDate, updatedDate } = Astro.props;
 ---
 
+<!doctype html>
 <html lang="en">
   <head>
     <BaseHead title={title} description={description} />
   </head>
 
-  <body class="antialiased tracking-tight">
+  <body class="antialiased tracking-tight font-sans">
     <ThemeToggle />
     <div class="min-h-screen flex flex-col pt-10 md:pt-8 p-8 bg-[var(--app-bg)] text-[var(--app-text)]">
       <main class="max-w-[var(--layout-main-max)] mx-auto w-full flex flex-col flex-1">
         <Header />
         <article>
-          <div class="mx-auto w-full max-w-[var(--layout-article-max)] px-3 text-[var(--app-text-soft)] py-5">
+          <div class="mx-auto w-full max-w-[var(--layout-article-max)] px-1 md:px-3 text-[var(--app-text-soft)] py-5">
             <div class="mb-4 py-2 text-left leading-none">
               <h1 class="mb-2 text-3xl font-bold text-[var(--app-text-heading)]">{title}</h1>
               <p class="mb-2 text-[var(--app-text-muted)]">{description}</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,9 +11,9 @@ import { SITE_DESCRIPTION, SITE_TITLE , GITHUB, EMAIL} from "../consts";
     </head>
     <body class="antialiased tracking-tight">
         <ThemeToggle />
-        <div
-            class="min-h-screen flex flex-col pt-10 md:pt-8 p-8 bg-[var(--app-bg)] text-[var(--app-text)]"
-        >
+		<div
+			class="min-h-dvh flex flex-col pt-8 pb-6 px-2 md:px-8 md:pt-8 md:pb-8 bg-[var(--app-bg)] text-[var(--app-text)]"
+		>
 			<main class="flex-1 max-w-[var(--layout-main-max)] mx-auto w-full flex flex-col justify-center -mt-6 md:-mt-10">
 				<div class="text-2xl pl-3 pb-2 space-y-4">
                     <h1>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -54,8 +54,18 @@
 }
 
 html {
-	min-width: 360px;
-	scrollbar-gutter: stable;
+	min-width: 320px;
+	overflow-x: hidden;
+}
+
+body {
+	overflow-x: hidden;
+}
+
+@media (min-width: 1024px) {
+	html {
+		scrollbar-gutter: stable;
+	}
 }
 
 .prose .anchor {
@@ -240,18 +250,15 @@ input[type="email"] {
 }
 
 @media (max-width: 767px) {
-	.prose p,
-	.prose li {
-		font-size: 1.08rem;
-		line-height: 1.9;
+	.prose img {
+		max-width: 92%;
 	}
 
 	.prose table {
 		display: block;
+		max-width: 100%;
 		overflow-x: auto;
 		-webkit-overflow-scrolling: touch;
-		width: max-content;
-		min-width: 100%;
 	}
 
 	.prose th,


### PR DESCRIPTION
## Summary
- fix mobile viewport behavior by switching to `min-h-dvh` on homepage and tightening horizontal overflow handling in global styles
- keep horizontal scrolling scoped to tables on small screens while preventing page-level side scrollbars
- align blog post layout behavior with list pages by adding doctype, applying consistent body font class, and refining article container padding

## Verification
- `pnpm build`