### PR TITLE
refactor(og): simplify image template

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,13 +1,17 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.2.5/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
 	"vcs": {
 		"enabled": false,
 		"clientKind": "git",
-		"useIgnoreFile": false
+		"useIgnoreFile": true
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": ["**/*.{astro,css,js,jsx,ts,tsx}"]
+		"includes": [
+			"**/*.{astro,css,js,jsx,ts,tsx}",
+			"!dist",
+			"!.astro"
+		]
 	},
 	"formatter": {
 		"enabled": true,
@@ -25,6 +29,11 @@
 	"javascript": {
 		"formatter": {
 			"quoteStyle": "double"
+		}
+	},
+	"css": {
+		"parser": {
+			"tailwindDirectives": true
 		}
 	},
 	"overrides": [

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,6 +3,7 @@
 // all pages through the use of the <BaseHead /> component.
 import "../styles/global.css";
 import type { ImageMetadata } from "astro";
+import { ClientRouter } from "astro:transitions";
 import FallbackImage from "../assets/og-image.png";
 import { SITE_TITLE } from "../consts";
 
@@ -33,9 +34,11 @@ const ogImageUrl =
 	href={new URL('rss.xml', Astro.site)}
 />
 <meta name="generator" content={Astro.generator} />
+<ClientRouter />
 
 <script is:inline>
 	(() => {
+		const previousTheme = window.__theme;
 		const key = "theme";
 		const root = document.documentElement;
 		const media = matchMedia("(prefers-color-scheme: dark)");
@@ -56,19 +59,67 @@ const ogImageUrl =
 			apply(next);
 		};
 
-		window.__theme = { get: getSaved, set: setTheme, apply };
+		const modes = ["light", "dark", "system"];
+		const updateThemeToggle = (button) => {
+			const current = getSaved();
+			const icons = Array.from(button.querySelectorAll("[data-theme-icon]"));
+			for (const icon of icons) {
+				icon.hidden = icon.dataset.themeIcon !== current;
+			}
+			const nextTheme = modes[(modes.indexOf(current) + 1) % modes.length];
+			button.setAttribute("aria-label", `Theme: ${current}. Click for ${nextTheme}.`);
+			button.title = `Theme: ${current}`;
+		};
+		const initThemeToggles = () => {
+			for (const button of document.querySelectorAll(".theme-toggle-btn")) {
+				if (button.dataset.themeToggleBound !== "true") {
+					button.addEventListener("click", () => {
+						const current = getSaved();
+						setTheme(modes[(modes.indexOf(current) + 1) % modes.length]);
+						updateThemeToggle(button);
+					});
+					button.dataset.themeToggleBound = "true";
+				}
+				updateThemeToggle(button);
+			}
+		};
+		const refreshEmbeds = () => {
+			window.twttr?.widgets?.load?.();
+		};
+		const initPage = () => {
+			apply(getSaved());
+			initThemeToggles();
+			refreshEmbeds();
+		};
 
-		apply(getSaved());
+		window.__theme = {
+			get: getSaved,
+			set: setTheme,
+			apply,
+			init: initThemeToggles,
+			__pageLoadBound: previousTheme?.__pageLoadBound === true,
+			__systemBound: previousTheme?.__systemBound === true,
+		};
+
 		const syncSystem = () => {
 			if (getSaved() === "system") {
 				apply("system");
+				initThemeToggles();
 			}
 		};
-		if (typeof media.addEventListener === "function") {
-			media.addEventListener("change", syncSystem);
-		} else {
-			media.addListener(syncSystem);
+		if (!window.__theme.__systemBound) {
+			if (typeof media.addEventListener === "function") {
+				media.addEventListener("change", syncSystem);
+			} else {
+				media.addListener(syncSystem);
+			}
+			window.__theme.__systemBound = true;
 		}
+		if (!window.__theme.__pageLoadBound) {
+			document.addEventListener("astro:page-load", initPage);
+			window.__theme.__pageLoadBound = true;
+		}
+		initPage();
 	})();
 </script>
 

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -17,38 +17,8 @@ import { Moon, Sun, TvMinimal } from "@lucide/astro";
 	</div>
 </div>
 
-<script is:inline>
+<script is:inline data-astro-rerun>
 	(() => {
-		const theme = window.__theme;
-		const button = document.querySelector(".theme-toggle-btn");
-		const icons = Array.from(document.querySelectorAll("[data-theme-icon]"));
-		if (!theme || !button || !icons.length) {
-			return;
-		}
-		const modes = ["light", "dark", "system"];
-
-		const updateUI = (mode) => {
-			for (const icon of icons) {
-				icon.hidden = icon.dataset.themeIcon !== mode;
-			}
-			const nextTheme = modes[(modes.indexOf(mode) + 1) % modes.length];
-			button.setAttribute("aria-label", `Theme: ${mode}. Click for ${nextTheme}.`);
-			button.title = `Theme: ${mode}`;
-		};
-
-		const select = (mode) => {
-			theme.set(mode);
-			updateUI(mode);
-		};
-
-		button.addEventListener("click", () => {
-			const current = theme.get();
-			const next = modes[(modes.indexOf(current) + 1) % modes.length];
-			select(next);
-		});
-
-		const initial = theme.get();
-		theme.apply(initial);
-		updateUI(initial);
+		window.__theme?.init?.();
 	})();
 </script>

--- a/src/content/blog/perfect-days/WorkdayTimeline.tsx
+++ b/src/content/blog/perfect-days/WorkdayTimeline.tsx
@@ -105,7 +105,7 @@ const PERIOD_META = {
 
 function timeToMinutes(time: string): number {
   const [h, m = "0"] = time.split(":")
-  return parseInt(h) * 60 + parseInt(m)
+  return parseInt(h, 10) * 60 + parseInt(m, 10)
 }
 
 const DAY_START = 0
@@ -128,15 +128,18 @@ function SlotBar({
 
   const wraps = end !== DAY_DURATION && end < start
   const segments = wraps
-    ? [{ left: (start / DAY_DURATION) * 100, width: ((DAY_DURATION - start) / DAY_DURATION) * 100 },
-       { left: 0, width: (end / DAY_DURATION) * 100 }]
-    : [{ left: (start / DAY_DURATION) * 100, width: ((end - start) / DAY_DURATION) * 100 }]
+    ? [
+        { id: `${slot.startTime}-${slot.endTime}-before-midnight`, left: (start / DAY_DURATION) * 100, width: ((DAY_DURATION - start) / DAY_DURATION) * 100 },
+        { id: `${slot.startTime}-${slot.endTime}-after-midnight`, left: 0, width: (end / DAY_DURATION) * 100 },
+      ]
+    : [{ id: `${slot.startTime}-${slot.endTime}`, left: (start / DAY_DURATION) * 100, width: ((end - start) / DAY_DURATION) * 100 }]
 
   return (
     <>
-      {segments.map((seg, i) => (
+      {segments.map((seg) => (
         <button
-          key={i}
+          key={seg.id}
+          type="button"
           onClick={onClick}
           aria-pressed={isActive}
           aria-label={`${slot.label}, ${slot.startTime} to ${slot.endTime}`}
@@ -184,7 +187,6 @@ export function WorkdayTimeline({
 
   return (
     <figure
-      role="figure"
       aria-label={`${title} timeline`}
       className="not-prose my-6 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 p-3 font-sans"
     >
@@ -196,14 +198,14 @@ export function WorkdayTimeline({
             <span className="text-xs text-neutral-400 dark:text-neutral-500 font-mono">{date}</span>
           )}
         </div>
-        <div className="flex items-center gap-3" aria-label="Period legend">
+        <ul className="flex items-center gap-3" aria-label="Period legend">
           {periods.map(({ period, meta }) => (
-            <div key={period} className="flex items-center gap-1">
+            <li key={period} className="flex items-center gap-1">
               <span className={`inline-block h-2 w-2 rounded-sm ${meta.barClass}`} aria-hidden="true" />
               <span className="text-[11px] text-neutral-500 dark:text-neutral-400">{meta.label}</span>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </figcaption>
 
       {/* Timeline bar */}

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -8,6 +8,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 
 type Props = CollectionEntry<"blog">["data"] & { slug: string };
 const { title, description, pubDate, updatedDate, slug } = Astro.props;
+const titleTransitionName = `post-title-${slug.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 ---
 
 <!doctype html>
@@ -24,7 +25,12 @@ const { title, description, pubDate, updatedDate, slug } = Astro.props;
         <article>
           <div class="mx-auto w-full max-w-[var(--layout-article-max)] px-1 md:px-3 text-[var(--app-text-soft)] py-5">
             <div class="mb-4 py-2 text-left leading-none">
-              <h1 class="mb-2 text-3xl font-bold text-[var(--app-text-heading)]">{title}</h1>
+              <h1
+                class="mb-2 text-3xl font-bold text-[var(--app-text-heading)]"
+                transition:name={titleTransitionName}
+              >
+                {title}
+              </h1>
               <p class="mb-2 text-[var(--app-text-muted)]">{description}</p>
               <div class="mb-2 text-xs text-[var(--app-text-muted)]">
                 <FormattedDate date={pubDate} />

--- a/src/lib/og-template.tsx
+++ b/src/lib/og-template.tsx
@@ -1,46 +1,62 @@
 interface OgTemplateProps {
 	title: string;
 	description: string;
-	siteName: string;
 }
 
 const fontFamily = "EB Garamond, Noto Serif TC";
 
-export function OgTemplate({ title, description, siteName }: OgTemplateProps) {
+export function OgTemplate({ title, description }: OgTemplateProps) {
 	const truncTitle = title.length > 60 ? `${title.slice(0, 57)}…` : title;
 	const truncDesc =
-		description.length > 120 ? `${description.slice(0, 117)}…` : description;
+		description.length > 90 ? `${description.slice(0, 87)}…` : description;
 
 	return (
-		<div style={{ display: "flex", flexDirection: "column", width: 1200, height: 630, backgroundColor: "#18181b" }}>
-			{/* Accent line */}
-			<div style={{ width: "100%", height: 3, backgroundColor: "#374151" }} />
-
-			{/* Main content */}
-			<div style={{ display: "flex", flexDirection: "column", flex: 1, paddingLeft: 80, paddingRight: 80, paddingTop: 64, paddingBottom: 48 }}>
-				{/* Site name */}
-				<div style={{ fontFamily, fontWeight: 400, fontSize: 20, color: "#6b7280", textTransform: "uppercase", letterSpacing: "0.15em", marginBottom: 32 }}>
-					{siteName}
-				</div>
-
-				{/* Title */}
-				<div style={{ fontFamily, fontWeight: 700, fontSize: 64, color: "#f3f4f6", lineHeight: 1.15, flex: 1 }}>
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "flex-start",
+				justifyContent: "center",
+				width: 1200,
+				height: 630,
+				paddingLeft: 96,
+				paddingRight: 96,
+				backgroundColor: "#18181b",
+				textAlign: "left",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "flex-start",
+				}}
+			>
+				<div
+					style={{
+						fontFamily,
+						fontWeight: 700,
+						fontSize: 72,
+						color: "#f3f4f6",
+						lineHeight: 1.12,
+					}}
+				>
 					{truncTitle}
 				</div>
-
-				{/* Description */}
 				{truncDesc && (
-					<div style={{ fontFamily, fontWeight: 400, fontSize: 28, color: "#9ca3af", lineHeight: 1.4, marginTop: 24 }}>
+					<div
+						style={{
+							fontFamily,
+							fontWeight: 400,
+							fontSize: 28,
+							color: "#a1a1aa",
+							lineHeight: 1.3,
+							marginTop: 10,
+						}}
+					>
 						{truncDesc}
 					</div>
 				)}
-			</div>
-
-			{/* Bottom bar */}
-			<div style={{ display: "flex", flexDirection: "row", alignItems: "center", paddingLeft: 80, paddingRight: 80, paddingBottom: 40 }}>
-				<div style={{ fontFamily, fontSize: 18, color: "#4b5563", letterSpacing: "0.05em" }}>
-					cantpr09ram.cc
-				</div>
 			</div>
 		</div>
 	);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -10,6 +10,8 @@ import { SITE_DESCRIPTION, SITE_TITLE } from "../../consts";
 const posts = (await getCollection("blog", ({ data }) => data.isdrift !== true)).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
+const getPostTransitionName = (id: string) =>
+	`post-title-${id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 ---
 
 <!doctype html>
@@ -31,7 +33,10 @@ const posts = (await getCollection("blog", ({ data }) => data.isdrift !== true))
 								href={`/blog/${post.id}/`}
 								class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-md px-1 py-0.5"
 							>
-								<p class="min-w-0 flex-1 text-lg font-semibold text-[var(--app-text-heading)]">
+								<p
+									class="min-w-0 flex-1 text-lg font-semibold text-[var(--app-text-heading)]"
+									transition:name={getPostTransitionName(post.id)}
+								>
 									{post.data.title}
 								</p>
 								<p class="shrink-0 text-xs text-[var(--app-text-muted)]">

--- a/src/pages/og/[...slug].png.ts
+++ b/src/pages/og/[...slug].png.ts
@@ -3,7 +3,6 @@ import { getCollection } from "astro:content";
 import { Resvg } from "@resvg/resvg-js";
 import { createElement } from "react";
 import satori from "satori";
-import { SITE_TITLE } from "../../consts";
 import { loadFonts } from "../../lib/og-font";
 import { OgTemplate } from "../../lib/og-template";
 
@@ -23,7 +22,7 @@ export const GET: APIRoute = async ({ props }) => {
 	const fonts = await loadFonts();
 
 	const svg = await satori(
-		createElement(OgTemplate, { title, description, siteName: SITE_TITLE }),
+		createElement(OgTemplate, { title, description }),
 		{ width: 1200, height: 630, fonts },
 	);
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,8 +1,9 @@
 @import url("https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&family=EB+Garamond:wght@400;500;600;700&family=Noto+Serif+TC:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
-@variant dark (&:where(.dark, .dark *));
 @import "./admonition.css";
 @import "katex/dist/katex.min.css";
+
+@custom-variant dark (&:where(.dark, .dark *));
 
 .katex-display {
 	overflow-x: auto;
@@ -72,6 +73,49 @@ html::-webkit-scrollbar {
 
 body {
 	overflow-x: hidden;
+}
+
+@keyframes view-fade-out {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
+	}
+}
+
+@keyframes view-fade-in-up {
+	from {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	::view-transition-old(root) {
+		animation: view-fade-out 120ms ease both;
+	}
+
+	::view-transition-new(root) {
+		animation: view-fade-in-up 180ms cubic-bezier(0.22, 1, 0.36, 1) both;
+	}
+
+	::view-transition-group(*) {
+		animation-duration: 180ms;
+		animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	::view-transition-old(*),
+	::view-transition-new(*),
+	::view-transition-group(*) {
+		animation: none;
+	}
 }
 
 .prose .anchor {


### PR DESCRIPTION
## Summary
- simplify the OG image template to title and description only
- align the OG text block to the left
- remove the site name and footer text from generated OG images

## Tests
- pnpm lint
- pnpm build