### PR TITLE
feat(ui): add Tailwind design system primitives

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,8 +1,11 @@
 ---
+import { GitPullRequest } from "@lucide/astro";
 import { execSync } from "node:child_process";
 import { NAME } from "../consts";
 
 const today = new Date();
+const commitBaseUrl =
+	"https://github.com/cantpr09ram/cantpr09ram.github.io/commit";
 const revision = (() => {
 	try {
 		return execSync("git rev-parse --short HEAD", {
@@ -12,14 +15,25 @@ const revision = (() => {
 		return "unknown";
 	}
 })();
+const revisionUrl =
+	revision === "unknown" ? undefined : `${commitBaseUrl}/${revision}`;
 ---
 
-<footer
-	class="mt-auto flex flex-wrap items-baseline justify-center gap-x-3 gap-y-1 pt-6 text-center text-xs"
->
+<footer class="footer-meta">
 	<p>&copy; {today.getFullYear()} {NAME}. All rights reserved.</p>
 	<p>This Too Shall Pass</p>
 	<p>251</p>
-	<p>{revision}</p>
-	
+	{
+		revisionUrl ? (
+			<a class="footer-revision" href={revisionUrl} aria-label={`Git commit ${revision}`}>
+				<GitPullRequest size={12} aria-hidden="true" />
+				<span>{revision}</span>
+			</a>
+		) : (
+			<p class="footer-revision">
+				<GitPullRequest size={12} aria-hidden="true" />
+				<span>{revision}</span>
+			</p>
+		)
+	}
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,11 +1,9 @@
 ---
 import { SITE_DESCRIPTION } from "../consts";
-const navLinks = [
-	{ href: "/", label: SITE_DESCRIPTION },
-];
+const navLinks = [{ href: "/", label: SITE_DESCRIPTION }];
 
 const baseClass =
-	"transition-all hover:text-neutral-800 dark:hover:text-neutral-200 flex items-center relative py-1 px-2 m-1";
+	"flex items-center relative py-1 px-2 m-1 transition-all hover:text-neutral-800 dark:hover:text-neutral-200";
 ---
 
 <header class="lg:top-2">

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -3,10 +3,10 @@ import { Moon, Sun, TvMinimal } from "@lucide/astro";
 ---
 
 <div class="absolute right-4 top-4 z-40 md:right-6 md:top-6">
-	<div class="theme-toggle rounded-full bg-[var(--app-bg)] p-1">
+	<div class="theme-toggle theme-toggle-panel">
 		<button
 			type="button"
-			class="theme-toggle-btn rounded-full p-2 text-[var(--app-text)] transition-colors hover:bg-zinc-200/50 dark:hover:bg-zinc-700/50"
+			class="theme-toggle-btn theme-toggle-button"
 			aria-label="Theme toggle"
 			title="Theme"
 		>

--- a/src/layouts/BaseBody.astro
+++ b/src/layouts/BaseBody.astro
@@ -12,9 +12,9 @@ interface Props {
 }
 
 const {
-	bodyClass = "antialiased tracking-tight font-sans",
-	shellClass = "min-h-screen flex flex-col pt-10 md:pt-8 p-8 bg-[var(--app-bg)] text-[var(--app-text)]",
-	mainClass = "max-w-[var(--layout-main-max)] mx-auto w-full flex flex-col flex-1",
+	bodyClass = "ds-body",
+	shellClass = "page-shell",
+	mainClass = "page-main",
 	showHeader = false,
 	showFooter = false,
 } = Astro.props;

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -22,28 +22,28 @@ const titleTransitionName = `post-title-${slug.replace(/[^a-zA-Z0-9_-]/g, "-")}`
 
   <BaseBody showHeader showFooter>
         <article>
-          <div class="mx-auto w-full max-w-[var(--layout-article-max)] px-1 md:px-3 text-[var(--app-text-soft)] py-5">
-            <div class="mb-4 py-2 text-left leading-none">
+          <div class="article-frame">
+            <div class="article-header">
               <h1
-                class="mb-2 text-3xl font-bold text-[var(--app-text-heading)]"
+                class="article-title"
                 transition:name={titleTransitionName}
               >
                 {title}
               </h1>
-              <p class="mb-2 text-[var(--app-text-muted)]">{description}</p>
+              <p class="mb-2 text-app-text-muted">{description}</p>
               {
                 seriesContext && (
-                  <p class="mb-2 text-sm text-[var(--app-text-muted)]">
+                  <p class="mb-2 text-sm text-app-text-muted">
                     <a
                       href={`/blog/?series=${seriesContext.series.slug}`}
-                      class="font-medium text-[var(--app-text)] underline-offset-4 hover:underline"
+                      class="content-link font-medium text-app-text"
                     >
                       {seriesContext.series.title}
                     </a>
                   </p>
                 )
               }
-              <div class="mb-2 text-xs text-[var(--app-text-muted)]">
+              <div class="mb-2 text-xs text-app-text-muted">
                 <FormattedDate date={pubDate} />
                 {
                   updatedDate && (

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -21,7 +21,7 @@ const globeConfig = {
 		<BaseHead title="404" description="Page not found" />
 	</head>
 	<BaseBody
-		bodyClass="antialiased max-w-[var(--layout-main-max)] mx-4 mt-8 lg:mx-auto bg-[var(--app-bg)] text-[var(--app-text)]"
+		bodyClass="ds-body max-w-main mx-4 mt-8 lg:mx-auto bg-app-surface text-app-text"
 		shellClass=""
 		mainClass="flex-auto min-w-0 mt-6 flex flex-col px-2 md:px-0"
 	>
@@ -33,8 +33,8 @@ const globeConfig = {
 				mapBrightness={globeConfig.mapBrightness}
 				initialLocation={globeConfig.initialLocation}
 			/>
-			<p>Hello from <a class="text-[var(--app-text-muted)] hover:text-[var(--app-text)] hover:underline" href="https://en.wikipedia.org/wiki/Taiwan">Taiwan</a></p>
-			<a class="text-[var(--app-text-muted)] hover:text-[var(--app-text)] hover:underline" href="/">GO BACK</a>
+			<p>Hello from <a class="muted-link" href="https://en.wikipedia.org/wiki/Taiwan">Taiwan</a></p>
+			<a class="muted-link" href="/">GO BACK</a>
 
 		</section>
 	</BaseBody>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -20,11 +20,11 @@ const getPostTransitionName = (id: string) =>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 	</head>
 	<BaseBody showHeader showFooter>
-			<section class="pl-2 py-5">
+			<section class="blog-list-section">
 				{
 					series.map((item) => (
 						<h1
-							class="mb-4 text-2xl font-semibold text-[var(--app-text-heading)]"
+							class="mb-4 text-2xl font-semibold text-app-heading"
 							data-series-title={item.slug}
 							hidden
 						>
@@ -32,21 +32,21 @@ const getPostTransitionName = (id: string) =>
 						</h1>
 					))
 				}
-				<ul class="space-y-1" data-post-list="all">
+				<ul class="blog-list" data-post-list="all">
 					{
 					posts.map((post) => (
 						<li data-series-slug={post.data.series?.slug ?? ""}>
-							<div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-md px-1 py-0.5">
-								<div class="min-w-0 flex-1 text-lg font-semibold text-[var(--app-text-heading)]">
+							<div class="post-row">
+								<div class="post-title">
 									<a
 										href={`/blog/${post.id}/`}
-										class="underline-offset-4 hover:underline"
+										class="content-link"
 										transition:name={getPostTransitionName(post.id)}
 									>
 										{post.data.title}
 									</a>
 								</div>
-								<p class="shrink-0 text-xs text-[var(--app-text-muted)]">
+								<p class="post-date">
 									<FormattedDate date={post.data.pubDate} />
 								</p>
 							</div>
@@ -57,22 +57,22 @@ const getPostTransitionName = (id: string) =>
 				{
 					series.map((item) => (
 						<ul
-							class="space-y-1"
+							class="blog-list"
 							data-post-list={item.slug}
 							hidden
 						>
 							{item.posts.map((post) => (
 								<li>
-									<div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-md px-1 py-0.5">
-										<div class="min-w-0 flex-1 text-lg font-semibold text-[var(--app-text-heading)]">
+									<div class="post-row">
+										<div class="post-title">
 											<a
 												href={`/blog/${post.id}/`}
-												class="underline-offset-4 hover:underline"
+												class="content-link"
 											>
 												{post.data.title}
 											</a>
 										</div>
-										<p class="shrink-0 text-xs text-[var(--app-text-muted)]">
+										<p class="post-date">
 											<FormattedDate date={post.data.pubDate} />
 										</p>
 									</div>
@@ -81,7 +81,7 @@ const getPostTransitionName = (id: string) =>
 						</ul>
 					))
 				}
-				<p class="text-sm text-[var(--app-text-muted)]" data-empty-series hidden>
+				<p class="text-sm text-app-text-muted" data-empty-series hidden>
 					No posts in this series.
 				</p>
 			</section>
@@ -108,7 +108,7 @@ const getPostTransitionName = (id: string) =>
 				} else {
 					filter.removeAttribute("aria-current");
 				}
-				filter.classList.toggle("text-[var(--app-text)]", isActive);
+				filter.classList.toggle("text-app-text", isActive);
 				filter.classList.toggle("font-medium", isActive);
 			}
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,12 +20,12 @@ const description = me.data.description ?? SITE_DESCRIPTION;
 		<BaseHead title={title} description={description} />
 	</head>
 	<BaseBody
-		bodyClass="antialiased tracking-tight"
-		shellClass="min-h-dvh flex flex-col pt-8 pb-6 px-2 md:px-8 md:pt-8 md:pb-8 bg-[var(--app-bg)] text-[var(--app-text)]"
-		mainClass="flex-1 max-w-[var(--layout-main-max)] mx-auto w-full flex flex-col"
+		bodyClass="ds-body"
+		shellClass="home-shell"
+		mainClass="home-main"
 		showFooter
 	>
-		<section class="flex flex-1 flex-col justify-center pb-[10dvh]">
+		<section class="home-content">
 			<div class="pl-3 pb-2 space-y-5">
 				<div class="prose max-w-none">
 					<Content />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -326,11 +326,110 @@ input[type="email"] {
 	--font-mono: "JetBrains Mono", "Iansui", monospace;
 }
 
+@theme inline {
+	--color-app-surface: var(--app-bg);
+	--color-app-text: var(--app-text);
+	--color-app-text-soft: var(--app-text-soft);
+	--color-app-text-muted: var(--app-text-muted);
+	--color-app-heading: var(--app-text-heading);
+	--color-app-code-bg: var(--code-bg);
+	--color-app-code-border: var(--code-border);
+	--color-app-code-inline: var(--code-inline-bg);
+	--container-main: var(--layout-main-max);
+	--container-article: var(--layout-article-max);
+	--container-narrow: var(--layout-narrow-max);
+	--container-anchor: var(--layout-anchor-max);
+}
+
 .mono-date {
 	font-family: var(--font-mono);
 }
 
 @layer components {
+	.ds-body {
+		@apply antialiased tracking-tight font-sans;
+	}
+
+	.page-shell {
+		@apply min-h-screen flex flex-col pt-10 md:pt-8 p-8 bg-app-surface text-app-text;
+	}
+
+	.home-shell {
+		@apply min-h-dvh flex flex-col pt-8 pb-6 px-2 md:px-8 md:pt-8 md:pb-8 bg-app-surface text-app-text;
+	}
+
+	.page-main {
+		@apply max-w-main mx-auto w-full flex flex-col flex-1;
+	}
+
+	.home-main {
+		@apply flex-1 max-w-main mx-auto w-full flex flex-col;
+	}
+
+	.home-content {
+		@apply flex flex-1 flex-col pt-5;
+	}
+
+	.article-frame {
+		@apply mx-auto w-full max-w-article px-1 md:px-3 text-app-text-soft py-5;
+	}
+
+	.article-header {
+		@apply mb-4 py-2 text-left leading-none;
+	}
+
+	.article-title {
+		@apply mb-2 text-3xl font-bold text-app-heading;
+	}
+
+	.content-link {
+		@apply underline-offset-4 hover:underline;
+	}
+
+	.muted-link {
+		@apply text-app-text-muted hover:text-app-text hover:underline;
+	}
+
+	.blog-list-section {
+		@apply pl-2 py-5;
+	}
+
+	.blog-list {
+		@apply space-y-1;
+	}
+
+	.post-row {
+		@apply flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-md px-1 py-0.5;
+	}
+
+	.post-title {
+		@apply min-w-0 flex-1 text-lg font-semibold text-app-heading;
+	}
+
+	.post-date {
+		@apply shrink-0 text-xs text-app-text-muted;
+	}
+
+	.theme-toggle-panel {
+		@apply rounded-full bg-app-surface p-1;
+	}
+
+	.theme-toggle-button {
+		@apply rounded-full p-2 text-app-text transition-colors hover:bg-zinc-200/50 dark:hover:bg-zinc-700/50;
+	}
+
+	.footer-meta {
+		@apply mt-auto flex flex-wrap items-center justify-center gap-x-3 gap-y-1 pt-6 text-center text-xs;
+	}
+
+	.footer-meta > * {
+		@apply inline-flex min-h-4 items-center leading-none;
+	}
+
+	.footer-revision {
+		@apply gap-1 text-app-text-muted underline-offset-2 hover:text-app-text hover:underline;
+	}
+
 	.cactus-link {
 		@apply underline underline-offset-2 hover:decoration-2 hover:decoration-neutral-500 dark:hover:decoration-neutral-300;
 	}


### PR DESCRIPTION
## Summary
- add Tailwind theme aliases and reusable UI primitives
- apply design-system classes across layout, blog list, footer, and homepage
- link the footer revision hash to the GitHub commit page

## Test
- pnpm build